### PR TITLE
launch.sh: change '#!/bin/bash' to '#!/bin/sh'

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # launch.sh - kills ApplicationLauncher and execs the given args, restarts launcher
 # when eval returns.
 


### PR DESCRIPTION
This script doesn't depend on 'bash', so just change it to 'sh'.

This also fix a QA issue when build in Yocto:
  WARNING: QA Issue: applicationlauncher requires /bin/bash, but no providers in its RDEPENDS [file-rdeps]

Signed-off-by: Josh Wu josh.wu@atmel.com
